### PR TITLE
PR: Initial Structure for Appointment Creation Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Beauty Maker
 # Manual do Usuário:
+<<<<<<< HEAD
 
+=======
+>>>>>>> 04a2b84 (Update README.md)
 Sistema para Gestão de Salão de Beleza.
 
 # Acesso ao Sistema:
@@ -68,3 +71,7 @@ Caso o sistema identifique, no momento do login, que o usuário é um cliente, e
   .Visualizar a lista completa de serviços cadastrados pelos profissionais no sistema.
 
   .Acessar a relação de profissionais disponíveis, com nome e função, facilitando a escolha no momento do agendamento.
+<<<<<<< HEAD
+=======
+  
+>>>>>>> 04a2b84 (Update README.md)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Beauty Maker
 # Manual do Usuário:
-<<<<<<< HEAD
-
-=======
->>>>>>> 04a2b84 (Update README.md)
 Sistema para Gestão de Salão de Beleza.
 
 # Acesso ao Sistema:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Beauty Maker
 # Manual do Usuário:
+
 Sistema para Gestão de Salão de Beleza.
 
 # Acesso ao Sistema:
@@ -67,4 +68,3 @@ Caso o sistema identifique, no momento do login, que o usuário é um cliente, e
   .Visualizar a lista completa de serviços cadastrados pelos profissionais no sistema.
 
   .Acessar a relação de profissionais disponíveis, com nome e função, facilitando a escolha no momento do agendamento.
-  

--- a/app/src/main/java/com/doo/finalActv/beautymaker/model/SelectableAppointmentElement.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/model/SelectableAppointmentElement.java
@@ -1,0 +1,5 @@
+package com.doo.finalActv.beautymaker.model;
+
+public interface SelectableAppointmentElement {
+  
+}

--- a/app/src/main/java/com/doo/finalActv/beautymaker/model/SelectableAppointmentElement.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/model/SelectableAppointmentElement.java
@@ -1,5 +1,10 @@
 package com.doo.finalActv.beautymaker.model;
 
+/**
+ * Marker interface to indicate that an object represents a selectable appointment element.
+ * Classes implementing this interface can be treated as selectable in the context of
+ * appointment-related operations.
+ */
 public interface SelectableAppointmentElement {
   
 }

--- a/app/src/main/java/com/doo/finalActv/beautymaker/model/ServiceData.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/model/ServiceData.java
@@ -3,7 +3,7 @@ package com.doo.finalActv.beautymaker.model;
 import java.time.LocalDate;
 
 
-public class ServiceData {
+public class ServiceData  implements SelectableAppointmentElement {
     public String name;
     public String description;
     public int price; // in cents

--- a/app/src/main/java/com/doo/finalActv/beautymaker/model/ServiceData.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/model/ServiceData.java
@@ -4,22 +4,35 @@ import java.time.LocalDate;
 
 
 public class ServiceData  implements SelectableAppointmentElement {
-    public String name;
-    public String description;
-    public int price; // in cents
-    public int duration; // in seconds
+  public String name;
+  public String description;
+  public int price; // in cents
+  public int duration; // in seconds
 
-    public ServiceData(String name, String description, int price, int duration) {
-        this.name = name;
-        this.description = description;
-        this.price = price;
-        this.duration = duration;
-    }
+  public ServiceData(String name, String description, int price, int duration) {
+      this.name = name;
+      this.description = description;
+      this.price = price;
+      this.duration = duration;
+  }
 
-    public ServiceData() {
-        this.name = "";
-        this.description = "";
-        this.price = 0;
-        this.duration = 0;
-    }
+  public ServiceData() {
+      this.name = "";
+      this.description = "";
+      this.price = 0;
+      this.duration = 0;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ServiceData)) return false;
+    ServiceData that = (ServiceData) o;
+    return (
+        price == that.price &&
+        duration == that.duration &&
+        name.equals(that.name) &&
+        description.equals(that.description)
+    );
+  }
 }

--- a/app/src/main/java/com/doo/finalActv/beautymaker/model/ServiceData.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/model/ServiceData.java
@@ -16,6 +16,13 @@ public class ServiceData  implements SelectableAppointmentElement {
       this.duration = duration;
   }
 
+  public ServiceData(ServiceData other) {
+      this.name = other.name;
+      this.description = other.description;
+      this.price = other.price;
+      this.duration = other.duration;
+  }
+
   public ServiceData() {
       this.name = "";
       this.description = "";

--- a/app/src/main/java/com/doo/finalActv/beautymaker/model/StaffData.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/model/StaffData.java
@@ -3,7 +3,7 @@ package com.doo.finalActv.beautymaker.model;
 import java.time.LocalDate;
 
 
-public class StaffData {
+public class StaffData implements SelectableAppointmentElement {
   public String name;
   public float rating;
   public int ratingCount;

--- a/app/src/main/java/com/doo/finalActv/beautymaker/model/StaffData.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/model/StaffData.java
@@ -16,6 +16,13 @@ public class StaffData implements SelectableAppointmentElement {
     this.experience = experience;
   }
 
+  public StaffData(StaffData other) {
+    this.name = other.name;
+    this.rating = other.rating;
+    this.ratingCount = other.ratingCount;
+    this.experience = other.experience;
+  }
+
   public StaffData() {
     this.name = "";
     this.rating = 0.0f;

--- a/app/src/main/java/com/doo/finalActv/beautymaker/model/StaffData.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/model/StaffData.java
@@ -21,4 +21,18 @@ public class StaffData implements SelectableAppointmentElement {
     this.rating = 0.0f;
     this.experience = LocalDate.now();
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof StaffData)) return false;
+    StaffData that = (StaffData) o;
+
+    return (
+        Float.compare(that.rating, rating) == 0 &&
+        ratingCount == that.ratingCount &&
+        name.equals(that.name) &&
+        experience.equals(that.experience)
+    );
+  }
 }

--- a/app/src/main/java/com/doo/finalActv/beautymaker/model/ui/MenuEntry.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/model/ui/MenuEntry.java
@@ -44,6 +44,7 @@ public class MenuEntry {
   private void updateSelection() {
     if (this.menuPanel instanceof MenuCardPanel menuCardPanel) {
       menuCardPanel.setSelected(this.isSelected);
+      this.viewPanel.setVisible(this.isSelected);
     }
   }
 

--- a/app/src/main/java/com/doo/finalActv/beautymaker/serivce/appdata/AppData.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/serivce/appdata/AppData.java
@@ -8,9 +8,13 @@ import java.util.ArrayList;
 public class AppData {
   public ArrayList<StaffData> staffs;
   public ArrayList<ServiceData> services;
+  public StaffData selectedStaff;
+  public ServiceData selectedService;
 
   public AppData() {
     this.staffs = new ArrayList<>();
     this.services = new ArrayList<>();
+    this.selectedStaff = null;
+    this.selectedService = null;
   }
 }

--- a/app/src/main/java/com/doo/finalActv/beautymaker/serivce/event/model/AppointmentElementSelectedEvent.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/serivce/event/model/AppointmentElementSelectedEvent.java
@@ -1,5 +1,9 @@
 package com.doo.finalActv.beautymaker.serivce.event.model;
 
-public class AppointmentElementSelectedEvent {
-  
+public class AppointmentElementSelectedEvent<T extends AppointmentElementSelectedEvent> {
+  public final T selectedElement;
+
+  public AppointmentElementSelectedEvent(T selectedElement) {
+    this.selectedElement = selectedElement;
+  }
 }

--- a/app/src/main/java/com/doo/finalActv/beautymaker/serivce/event/model/AppointmentElementSelectedEvent.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/serivce/event/model/AppointmentElementSelectedEvent.java
@@ -1,0 +1,5 @@
+package com.doo.finalActv.beautymaker.serivce.event.model;
+
+public class AppointmentElementSelectedEvent {
+  
+}

--- a/app/src/main/java/com/doo/finalActv/beautymaker/serivce/event/model/AppointmentElementSelectedEvent.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/serivce/event/model/AppointmentElementSelectedEvent.java
@@ -1,6 +1,8 @@
 package com.doo.finalActv.beautymaker.serivce.event.model;
 
-public class AppointmentElementSelectedEvent<T extends AppointmentElementSelectedEvent> {
+import com.doo.finalActv.beautymaker.model.SelectableAppointmentElement;
+
+public class AppointmentElementSelectedEvent<T extends SelectableAppointmentElement> {
   public final T selectedElement;
 
   public AppointmentElementSelectedEvent(T selectedElement) {

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/BaseHomeView.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/BaseHomeView.java
@@ -92,6 +92,10 @@ abstract class BaseHomeView extends javax.swing.JInternalFrame {
     this.selectInitialMenuEntry();
   }
 
+  protected void selectMenuEntry(String key) {
+    EventManager.getInstance().publish(new MenuItemSelectedEvent(key));
+  }
+
   private void addLogo() {
     this.panelMenu.add(new LogoHome());
     this.panelMenu.add(javax.swing.Box.createVerticalStrut(20));
@@ -128,6 +132,7 @@ abstract class BaseHomeView extends javax.swing.JInternalFrame {
         }
       }
     });
+
   }
 
   private void addMenuItems() {

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/ClientHomeView.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/ClientHomeView.java
@@ -5,7 +5,8 @@ import com.doo.finalActv.beautymaker.ui.client.AppointmentsView;
 import com.doo.finalActv.beautymaker.ui.client.ProfileView;
 import com.doo.finalActv.beautymaker.ui.client.ServicesView;
 import com.doo.finalActv.beautymaker.ui.client.StaffView;
-
+import com.doo.finalActv.beautymaker.ui.client.cards.AppointmentSelection;
+import javax.swing.JPanel;
 
 public class ClientHomeView extends BaseHomeView {
 

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/MainWindow.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/MainWindow.java
@@ -41,7 +41,7 @@ public class MainWindow extends javax.swing.JFrame {
     this.showLoginView();
 
     // test porpose: mock login
-    //this.mockLogin();
+    this.mockLogin();
   }
 
   /**

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/MainWindow.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/MainWindow.java
@@ -40,8 +40,6 @@ public class MainWindow extends javax.swing.JFrame {
     this.startApplication();
     this.showLoginView();
 
-    // test porpose: mock login
-    this.mockLogin();
   }
 
   /**

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/CardListView.form
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/CardListView.form
@@ -2,8 +2,11 @@
 
 <Form version="1.3" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <Properties>
+    <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+      <Dimension value="[49150, 1000]"/>
+    </Property>
     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[1000, 1000]"/>
+      <Dimension value="[1000, 900]"/>
     </Property>
   </Properties>
   <AuxValues>
@@ -16,32 +19,11 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,2,-18,0,0,4,-80"/>
   </AuxValues>
 
-  <Layout>
-    <DimensionLayout dim="0">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="jScrollPane1" alignment="0" pref="988" max="32767" attributes="0"/>
-                  <Component id="titleLabel" alignment="1" pref="988" max="32767" attributes="0"/>
-              </Group>
-              <EmptySpace max="-2" attributes="0"/>
-          </Group>
-      </Group>
-    </DimensionLayout>
-    <DimensionLayout dim="1">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="1" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="titleLabel" min="-2" pref="100" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="jScrollPane1" pref="882" max="32767" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-          </Group>
-      </Group>
-    </DimensionLayout>
+  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
+    <Property name="axis" type="int" value="1"/>
   </Layout>
   <SubComponents>
     <Component class="javax.swing.JLabel" name="titleLabel">
@@ -50,9 +32,71 @@
           <Font name="Cantarell" size="15" style="1"/>
         </Property>
         <Property name="horizontalAlignment" type="int" value="0"/>
+        <Property name="alignmentX" type="float" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="Component.CENTER_ALIGNMENT" type="code"/>
+        </Property>
+        <Property name="horizontalTextPosition" type="int" value="0"/>
+        <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[32767, 32767]"/>
+        </Property>
+        <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[988, 100]"/>
+        </Property>
       </Properties>
     </Component>
+    <Component class="javax.swing.Box$Filler" name="filler1">
+      <Properties>
+        <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[32767, 20]"/>
+        </Property>
+        <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[0, 10]"/>
+        </Property>
+        <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[0, 10]"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.VerticalStrut"/>
+      </AuxValues>
+    </Component>
+    <Container class="javax.swing.JPanel" name="crrSelectionPanell">
+      <Properties>
+        <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[1200, 250]"/>
+        </Property>
+        <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[1200, 40]"/>
+        </Property>
+      </Properties>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
+    </Container>
+    <Component class="javax.swing.Box$Filler" name="filler2">
+      <Properties>
+        <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[32767, 20]"/>
+        </Property>
+        <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[0, 10]"/>
+        </Property>
+        <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[0, 10]"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.VerticalStrut"/>
+      </AuxValues>
+    </Component>
     <Container class="javax.swing.JScrollPane" name="jScrollPane1">
+      <Properties>
+        <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[1200, 820]"/>
+        </Property>
+        <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[1200, 820]"/>
+        </Property>
+      </Properties>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
       <SubComponents>

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/CardListView.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/CardListView.java
@@ -1,6 +1,11 @@
 package com.doo.finalActv.beautymaker.ui.client;
 
+import com.doo.finalActv.beautymaker.model.StaffData;
+import com.doo.finalActv.beautymaker.serivce.event.EventManager;
+import com.doo.finalActv.beautymaker.serivce.event.model.AppointmentElementSelectedEvent;
 import java.util.ArrayList;
+import java.awt.BorderLayout;
+import java.awt.Component;
 import javax.swing.Box;
 import javax.swing.JPanel;
 
@@ -27,42 +32,46 @@ public class CardListView<T extends JPanel> extends javax.swing.JPanel {
   private void initComponents() {
 
     titleLabel = new javax.swing.JLabel();
+    filler1 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 10), new java.awt.Dimension(0, 10), new java.awt.Dimension(32767, 20));
+    crrSelectionPanell = new javax.swing.JPanel();
+    filler2 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 10), new java.awt.Dimension(0, 10), new java.awt.Dimension(32767, 20));
     jScrollPane1 = new javax.swing.JScrollPane();
     cardContainer = new javax.swing.JPanel();
 
-    setPreferredSize(new java.awt.Dimension(1000, 1000));
+    setMaximumSize(new java.awt.Dimension(49150, 1000));
+    setPreferredSize(new java.awt.Dimension(1000, 900));
+    setLayout(new javax.swing.BoxLayout(this, javax.swing.BoxLayout.Y_AXIS));
 
     titleLabel.setFont(new java.awt.Font("Cantarell", 1, 15)); // NOI18N
     titleLabel.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
+    titleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+    titleLabel.setHorizontalTextPosition(javax.swing.SwingConstants.CENTER);
+    titleLabel.setMaximumSize(new java.awt.Dimension(32767, 32767));
+    titleLabel.setPreferredSize(new java.awt.Dimension(988, 100));
+    add(titleLabel);
+    add(filler1);
+
+    crrSelectionPanell.setMaximumSize(new java.awt.Dimension(1200, 250));
+    crrSelectionPanell.setPreferredSize(new java.awt.Dimension(1200, 40));
+    crrSelectionPanell.setLayout(new java.awt.BorderLayout());
+    add(crrSelectionPanell);
+    add(filler2);
+
+    jScrollPane1.setMaximumSize(new java.awt.Dimension(1200, 820));
+    jScrollPane1.setPreferredSize(new java.awt.Dimension(1200, 820));
 
     cardContainer.setLayout(new javax.swing.BoxLayout(cardContainer, javax.swing.BoxLayout.Y_AXIS));
     jScrollPane1.setViewportView(cardContainer);
 
-    javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
-    this.setLayout(layout);
-    layout.setHorizontalGroup(
-      layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-      .addGroup(layout.createSequentialGroup()
-        .addContainerGap()
-        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-          .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 988, Short.MAX_VALUE)
-          .addComponent(titleLabel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, 988, Short.MAX_VALUE))
-        .addContainerGap())
-    );
-    layout.setVerticalGroup(
-      layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-      .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
-        .addContainerGap()
-        .addComponent(titleLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 100, javax.swing.GroupLayout.PREFERRED_SIZE)
-        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-        .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 882, Short.MAX_VALUE)
-        .addContainerGap())
-    );
+    add(jScrollPane1);
   }// </editor-fold>//GEN-END:initComponents
 
 
   // Variables declaration - do not modify//GEN-BEGIN:variables
   private javax.swing.JPanel cardContainer;
+  private javax.swing.JPanel crrSelectionPanell;
+  private javax.swing.Box.Filler filler1;
+  private javax.swing.Box.Filler filler2;
   private javax.swing.JScrollPane jScrollPane1;
   private javax.swing.JLabel titleLabel;
   // End of variables declaration//GEN-END:variables
@@ -72,7 +81,7 @@ public class CardListView<T extends JPanel> extends javax.swing.JPanel {
       this.titleLabel.setText(this.title);
     } else {
       this.titleLabel.setText("Card List");
-    }
+    } 
   }
 
   public void updateCardList(ArrayList<T> cardList) {
@@ -87,5 +96,16 @@ public class CardListView<T extends JPanel> extends javax.swing.JPanel {
 
     this.cardContainer.revalidate();
     this.cardContainer.repaint();
+  }
+
+  public void updateSelectionPanel(JPanel selectionPanel) {
+    this.crrSelectionPanell.removeAll();
+    this.crrSelectionPanell.setPreferredSize(null);
+    this.crrSelectionPanell.add(selectionPanel, BorderLayout.CENTER);
+    this.crrSelectionPanell.revalidate();
+    this.crrSelectionPanell.repaint();
+    
+    this.revalidate();
+    this.repaint();
   }
 }

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/ServicesView.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/ServicesView.java
@@ -2,14 +2,18 @@ package com.doo.finalActv.beautymaker.ui.client;
 
 import com.doo.finalActv.beautymaker.serivce.appdata.ContentProvider;
 import com.doo.finalActv.beautymaker.serivce.appdata.DataChangeListener;
+import com.doo.finalActv.beautymaker.ui.client.cards.AppointmentSelection;
 import com.doo.finalActv.beautymaker.ui.client.cards.ServiceCard;
 import java.util.ArrayList;
-
+import javax.swing.JPanel;
 
 public class ServicesView extends CardListView implements DataChangeListener {
 
   public ServicesView() {
     super("Beauty Services");
+    super.updateSelectionPanel(new AppointmentSelection());
+    this.revalidate();
+    this.repaint();
     this.initialize();
   }
 
@@ -20,8 +24,6 @@ public class ServicesView extends CardListView implements DataChangeListener {
   @Override
   public void onDataChanged() {
     ArrayList<ServiceCard> serviceCards = new ArrayList<>();
-
-    ContentProvider provider = ContentProvider.getInstance();
 
     ContentProvider.getInstance().getServices().forEach(serviceData -> {
       ServiceCard serviceCard = new ServiceCard(serviceData);

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/StaffView.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/StaffView.java
@@ -1,18 +1,19 @@
 package com.doo.finalActv.beautymaker.ui.client;
 
-import com.doo.finalActv.beautymaker.model.StaffData;
 import com.doo.finalActv.beautymaker.serivce.appdata.ContentProvider;
 import com.doo.finalActv.beautymaker.serivce.appdata.DataChangeListener;
+import com.doo.finalActv.beautymaker.ui.client.cards.AppointmentSelection;
 import com.doo.finalActv.beautymaker.ui.client.cards.StaffCard;
 import java.util.ArrayList;
-import javax.swing.Box;
-import javax.swing.JLabel;
+import javax.swing.JPanel;
 
 public class StaffView extends CardListView implements DataChangeListener {
 
-
   public StaffView() {
     super("Beauty Agents");
+    super.updateSelectionPanel(new AppointmentSelection());
+    this.revalidate();
+    this.repaint();
     this.initialize();
   }
 
@@ -30,5 +31,7 @@ public class StaffView extends CardListView implements DataChangeListener {
     });
 
     super.updateCardList(staffCards);
+    this.revalidate();
+    this.repaint();
   }
 }

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/AppointmentElementCard.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/AppointmentElementCard.java
@@ -1,11 +1,13 @@
 package com.doo.finalActv.beautymaker.ui.client.cards;
 
 import com.doo.finalActv.beautymaker.model.SelectableAppointmentElement;
+import com.doo.finalActv.beautymaker.serivce.appdata.ContentProvider;
+import com.doo.finalActv.beautymaker.serivce.appdata.DataChangeListener;
 import com.doo.finalActv.beautymaker.serivce.event.EventManager;
 import com.doo.finalActv.beautymaker.serivce.event.model.AppointmentElementSelectedEvent;
 import java.awt.Color;
 
-public abstract class AppointmentElementCard<T extends SelectableAppointmentElement> extends javax.swing.JPanel {
+public abstract class AppointmentElementCard<T extends SelectableAppointmentElement> extends javax.swing.JPanel implements DataChangeListener {
 
   private Color selectedColor;
   private Color unselectedColor;
@@ -61,16 +63,23 @@ public abstract class AppointmentElementCard<T extends SelectableAppointmentElem
       }
     });
 
-    EventManager.getInstance().subscribe(
-        AppointmentElementSelectedEvent.class,
-        (event) -> {
-          if (event.selectedElement.equals(this.element)) {
-            this.setSelected(true);
-          } else {
-            this.setSelected(false);
-          }
-        }
-    );
+    ContentProvider.getInstance().addListener(this, "appointment");
+  }
+
+  @Override
+  public void onDataChanged() {
+    if(this.element == null) {
+      return;
+    }
+
+    if(
+        this.element.equals(ContentProvider.getInstance().getSelectedStaff()) ||
+        this.element.equals(ContentProvider.getInstance().getSelectedService())
+    ) {
+      this.setSelected(true);
+    } else {
+      this.setSelected(false);
+    }
   }
 
   private void updateAppearance() {

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/AppointmentElementCard.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/AppointmentElementCard.java
@@ -1,0 +1,88 @@
+package com.doo.finalActv.beautymaker.ui.client.cards;
+
+import com.doo.finalActv.beautymaker.model.SelectableAppointmentElement;
+import com.doo.finalActv.beautymaker.serivce.event.EventManager;
+import com.doo.finalActv.beautymaker.serivce.event.model.AppointmentElementSelectedEvent;
+import java.awt.Color;
+
+public abstract class AppointmentElementCard<T extends SelectableAppointmentElement> extends javax.swing.JPanel {
+
+  private Color selectedColor;
+  private Color unselectedColor;
+  private Color hoverColor;
+  private boolean isSelected = false;
+  private boolean isHovered = false;
+
+  protected T element;
+
+  public AppointmentElementCard(T element) {
+    this.unselectedColor = new java.awt.Color(204, 204, 204);
+    this.selectedColor = new java.awt.Color(153, 153, 153);
+    this.hoverColor = new java.awt.Color(192, 192, 192);
+    this.element = element;
+    initializeEvents();
+  }
+
+  public void setSelected(boolean selected) {
+    this.isSelected = selected;
+    this.updateAppearance();
+  }
+
+  public void toggleSelected(){
+    this.isSelected = !(this.isSelected);
+  }
+
+
+  // private functions
+
+  private void onMouseClick() {
+    EventManager.getInstance().publish(
+        new AppointmentElementSelectedEvent<>(this.element)
+    );
+  }
+
+  private void initializeEvents() {
+    this.addMouseListener(new java.awt.event.MouseAdapter() {
+      @Override
+      public void mouseEntered(java.awt.event.MouseEvent evt) {
+        AppointmentElementCard.this.isHovered = true;
+        AppointmentElementCard.this.updateAppearance();
+      }
+
+      @Override
+      public void mouseExited(java.awt.event.MouseEvent evt) {
+        AppointmentElementCard.this.isHovered = false;
+        AppointmentElementCard.this.updateAppearance();
+      }
+
+      @Override
+      public void mouseClicked(java.awt.event.MouseEvent evt) {
+        AppointmentElementCard.this.onMouseClick();
+      }
+    });
+
+    EventManager.getInstance().subscribe(
+        AppointmentElementSelectedEvent.class,
+        (event) -> {
+          if (event.selectedElement.equals(this.element)) {
+            this.setSelected(true);
+          } else {
+            this.setSelected(false);
+          }
+        }
+    );
+  }
+
+  private void updateAppearance() {
+    if (this.isHovered) {
+      this.setBackground(this.hoverColor);
+    } else {
+      if( this.isSelected) {
+        this.setBackground(this.selectedColor);
+      } else {
+        this.setBackground(this.unselectedColor);
+      }
+    }
+    this.repaint();
+  }
+}

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/AppointmentSelection.form
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/AppointmentSelection.form
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<Form version="1.3" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+  <Properties>
+    <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+      <Dimension value="[1000, 240]"/>
+    </Property>
+  </Properties>
+  <AuxValues>
+    <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
+    <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="1"/>
+    <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,0,-16,0,0,3,-24"/>
+  </AuxValues>
+
+  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
+    <Property name="axis" type="int" value="0"/>
+  </Layout>
+</Form>

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/AppointmentSelection.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/AppointmentSelection.java
@@ -1,0 +1,118 @@
+package com.doo.finalActv.beautymaker.ui.client.cards;
+
+import com.doo.finalActv.beautymaker.model.ServiceData;
+import com.doo.finalActv.beautymaker.model.StaffData;
+import com.doo.finalActv.beautymaker.serivce.appdata.ContentProvider;
+import com.doo.finalActv.beautymaker.serivce.appdata.DataChangeListener;
+import java.awt.Color;
+
+public class AppointmentSelection extends javax.swing.JPanel implements DataChangeListener {
+  private StaffData staff;
+  private ServiceData service;
+  
+  public AppointmentSelection() {
+    initialize();
+
+    this.staff = null;
+    this.service = null;
+    this.updateView();
+  }
+
+  public AppointmentSelection(StaffData staff, ServiceData service) {
+    initialize();
+
+    this.staff = staff;
+    this.service = service;
+    this.updateView();
+  }
+
+  public AppointmentSelection(StaffData staff) {
+    initialize();
+
+    this.staff = staff;
+    this.service = null;
+    this.updateView();
+  }
+
+  public AppointmentSelection(ServiceData service) {
+    initialize();
+
+    this.staff = null;
+    this.service = service;
+    this.updateView();
+  }
+
+  private void updateSelection(StaffData staff, ServiceData service) {
+    this.staff = staff;
+    this.service = service;
+    this.updateView();
+  }
+
+  private void updateSelection(StaffData staff) {
+    this.staff = staff;
+    this.service = null;
+    this.updateView();
+  }
+
+  private void updateSelection(ServiceData service) {
+    this.staff = null;
+    this.service = service;
+    this.updateView();
+  }
+
+  private void updateSelection() {
+    this.staff = null;
+    this.service = null;
+    this.updateView();
+  }
+
+  private void initialize() {
+    this.setLayout(new javax.swing.BoxLayout(this, javax.swing.BoxLayout.X_AXIS));
+    this.setPreferredSize(new java.awt.Dimension(1000, 40));
+    this.setMaximumSize(new java.awt.Dimension(1000, 40));
+    this.setBorder(javax.swing.BorderFactory.createLineBorder(Color.GREEN, 3));
+    this.setOpaque(false);
+    this.setVisible(true);
+
+    ContentProvider.getInstance().addListener(this, "appointment");
+  }
+
+  private void updateView() {
+    this.removeAll();
+
+    if(this.staff == null && this.service == null) {
+      this.setPreferredSize(new java.awt.Dimension(1000, 40));
+      this.setMaximumSize(new java.awt.Dimension(1000, 40));
+      this.setVisible(false);
+      
+    } else {
+      this.setPreferredSize(new java.awt.Dimension(1000, 240));
+      this.setMaximumSize(new java.awt.Dimension(1000, 240));
+      this.setLayout(new javax.swing.BoxLayout(this, javax.swing.BoxLayout.X_AXIS));
+      this.setBorder(javax.swing.BorderFactory.createLineBorder(Color.GREEN, 3));
+      this.setVisible(true);
+      this.setOpaque(false);
+      
+      if(this.staff != null){
+        StaffCard staffCard = new StaffCard(new StaffData(this.staff));
+        //staffCard.setMaximumSize(new java.awt.Dimension(490, 240));
+        this.add(staffCard);
+      }
+      if(this.service != null){
+        ServiceCard serviceCard = new ServiceCard(new ServiceData(this.service));
+        //serviceCard.setMaximumSize(new java.awt.Dimension(490, 240));
+        this.add(serviceCard);
+      }
+    }
+
+    this.revalidate();
+    this.repaint();
+  }
+
+  @Override
+  public void onDataChanged() {
+    ServiceData serviceData = ContentProvider.getInstance().getSelectedService();
+    StaffData staffData = ContentProvider.getInstance().getSelectedStaff();
+    this.updateSelection(staffData, serviceData);
+  }
+}

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/ServiceCard.form
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/ServiceCard.form
@@ -3,7 +3,7 @@
 <Form version="1.3" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <Properties>
     <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
-      <Color blue="ff" green="ff" red="ff" type="rgb"/>
+      <Color blue="cc" green="cc" red="cc" type="rgb"/>
     </Property>
     <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
       <Dimension value="[580, 200]"/>

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/ServiceCard.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/ServiceCard.java
@@ -8,12 +8,13 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import javax.swing.JLabel;
 
-public class ServiceCard extends javax.swing.JPanel {
-  private ServiceData serviceData;
+// TODO: use AppointmentElementCard as a base class
 
+public class ServiceCard extends AppointmentElementCard<ServiceData> {
   public ServiceCard(ServiceData serviceData) {
+    super(serviceData);
     initComponents();
-    this.serviceData = serviceData;
+
     this.initialize();
   }
 
@@ -31,7 +32,7 @@ public class ServiceCard extends javax.swing.JPanel {
     durationField = new javax.swing.JLabel();
     priceField = new javax.swing.JLabel();
 
-    setBackground(new java.awt.Color(255, 255, 255));
+    setBackground(new java.awt.Color(204, 204, 204));
     setMaximumSize(new java.awt.Dimension(580, 200));
     setMinimumSize(new java.awt.Dimension(580, 200));
 
@@ -82,9 +83,11 @@ public class ServiceCard extends javax.swing.JPanel {
   // End of variables declaration//GEN-END:variables
 
   private void initialize() {
-    nameField.setText(this.serviceData.name);
+    ServiceData serviceData = (ServiceData) super.element;
+
+    nameField.setText(serviceData.name);
     descriptionField.setText(
-        this.formatDescription(this.serviceData.description)
+        this.formatDescription(serviceData.description)
     );
     durationField.setText(this.getFormattedDuration());
     priceField.setText(this.getFormattedPrice());
@@ -95,7 +98,7 @@ public class ServiceCard extends javax.swing.JPanel {
 
   private String getFormattedDuration() {
     String result = "Duration: ";
-    int seconds = this.serviceData.duration;
+    int seconds = ((ServiceData) super.element).duration;
     int hours = seconds / 3600;
     int minutes = (seconds % 3600) / 60;
     int remainingSeconds = seconds % 60;
@@ -114,11 +117,12 @@ public class ServiceCard extends javax.swing.JPanel {
   private String getFormattedPrice() {
     // only show price > 0 (price is displayed only if a employee is assigned)
     // if price is 0, means that the service is waiting for an employee to be assigned
-    if (this.serviceData.price <= 0) {
+    ServiceData serviceData = (ServiceData) super.element;
+    if (serviceData.price <= 0) {
       return "";
     }
 
-    return "Price: $" + String.format("%.2f", this.serviceData.price / 100.0);
+    return "Price: $" + String.format("%.2f", serviceData.price / 100.0);
   }
 
   private String formatDescription(String description) {
@@ -127,7 +131,7 @@ public class ServiceCard extends javax.swing.JPanel {
     }
 
     String result = "<html>";
-    result += this.serviceData.description.replace("\n", "<br>");
+    result += ((ServiceData) super.element).description.replace("\n", "<br>");
     result += "</html>";
     return result;
   }

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/StaffCard.form
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/StaffCard.form
@@ -3,7 +3,7 @@
 <Form version="1.3" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <Properties>
     <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
-      <Color blue="ff" green="ff" red="ff" type="rgb"/>
+      <Color blue="cc" green="cc" red="cc" type="rgb"/>
     </Property>
     <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
       <Dimension value="[580, 200]"/>

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/StaffCard.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/StaffCard.java
@@ -85,7 +85,8 @@ public class StaffCard extends AppointmentElementCard<StaffData> {
   // End of variables declaration//GEN-END:variables
 
   private void initialize() {
-    nameField.setText(((StaffData) super.element).name); 
+    StaffData staffData = (StaffData) super.element;
+    nameField.setText(staffData.name); 
     experienceField.setText("Experience: " + this.getFormattedExperience());
     this.configureRatingPanel();
 

--- a/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/StaffCard.java
+++ b/app/src/main/java/com/doo/finalActv/beautymaker/ui/client/cards/StaffCard.java
@@ -3,16 +3,17 @@ package com.doo.finalActv.beautymaker.ui.client.cards;
 import com.doo.finalActv.beautymaker.model.StaffData;
 import java.awt.Color;
 import java.awt.Component;
-import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import javax.swing.JLabel;
 
-public class StaffCard extends javax.swing.JPanel {
-  private StaffData staffData;
+// TODO: use AppointmentElementCard as a base class
+
+public class StaffCard extends AppointmentElementCard<StaffData> {
 
   public StaffCard(StaffData staffData) {
+    super(staffData);
     initComponents();
-    this.staffData = staffData;
+
     this.initialize();
   }
 
@@ -30,7 +31,7 @@ public class StaffCard extends javax.swing.JPanel {
     ratingPanel = new javax.swing.JPanel();
     jLabel1 = new javax.swing.JLabel();
 
-    setBackground(new java.awt.Color(255, 255, 255));
+    setBackground(new java.awt.Color(204, 204, 204));
     setMaximumSize(new java.awt.Dimension(580, 200));
     setMinimumSize(new java.awt.Dimension(580, 200));
 
@@ -84,7 +85,7 @@ public class StaffCard extends javax.swing.JPanel {
   // End of variables declaration//GEN-END:variables
 
   private void initialize() {
-    nameField.setText(this.staffData.name);
+    nameField.setText(((StaffData) super.element).name); 
     experienceField.setText("Experience: " + this.getFormattedExperience());
     this.configureRatingPanel();
 
@@ -93,9 +94,12 @@ public class StaffCard extends javax.swing.JPanel {
   }
 
   private String getFormattedExperience() {
-    int years = (int) java.time.temporal.ChronoUnit.YEARS.between(this.staffData.experience, java.time.LocalDate.now());
+    int years = (int) java.time.temporal.ChronoUnit.YEARS.between(
+        ((StaffData) super.element).experience,
+        java.time.LocalDate.now()
+    );
     int remaningMonths = (int) ChronoUnit.MONTHS.between(
-        this.staffData.experience.plusYears(years), java.time.LocalDate.now()
+        ((StaffData) super.element).experience.plusYears(years), java.time.LocalDate.now()
     );
 
     String result = years + " year(s)";
@@ -107,17 +111,19 @@ public class StaffCard extends javax.swing.JPanel {
 
   private void configureRatingPanel() {
     ratingPanel.removeAll();
-    if (this.staffData.ratingCount == 0) {
+    StaffData staffData = (StaffData) super.element;
+
+    if (staffData.ratingCount == 0) {
       JLabel message = new JLabel("Not rated yet");
       ratingPanel.add(message);
     } else {
       // TODO : Implement a visual representation of the rating
       String ratingMessage = (
-          "★".repeat((int) this.staffData.rating) +
-          "☆".repeat(5 - (int) this.staffData.rating) +
-          " (" + String.format("%.1f", this.staffData.rating) + 
+          "★".repeat((int) staffData.rating) +
+          "☆".repeat(5 - (int) staffData.rating) +
+          " (" + String.format("%.1f", staffData.rating) + 
           " - " +
-          this.staffData.ratingCount + " ratings)"
+          staffData.ratingCount + " ratings)"
       );
 
       JLabel ratingLabel = new JLabel(ratingMessage);

--- a/app/src/test/java/com/doo/finalActv/beautymaker/utils/TestUtils.java
+++ b/app/src/test/java/com/doo/finalActv/beautymaker/utils/TestUtils.java
@@ -16,8 +16,6 @@ import java.sql.*;
 import java.sql.SQLException;
 
 import java.time.LocalDate;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class TestUtils {
 


### PR DESCRIPTION
This PR introduces the initial structure for the appointment creation flow.

## Main Changes:
- **Client Views Updated**: Both the *staff* and *service* client views now support item selection.
- **Appointment Selection Logic**: 
  - An appointment consists of a selected **staff** and a **service**.
  - Clicking a card in the list selects that item as part of the appointment.
  - The currently selected item is displayed above the list view in a new panel.
  - Selecting the same item again will deselect it.
  - Selecting a different item will replace the previously selected one.
- **New Selection Panel**:
  - Appears above the staff/service lists.
  - Shows the currently selected item.
  - Allows deselection by clicking the displayed card.
- **Integration with `ContentProvider`**:
  - Selection state (`selectedStaff` and `selectedService`) is stored in `AppData` by `ContentProvider`.
  - Views react to changes via `EventListener` to stay in sync with shared state.
- **Manual Testing**: Functionality was manually tested and worked as expected.
